### PR TITLE
Piping output to null to prevent script fail

### DIFF
--- a/Install-Node.sh
+++ b/Install-Node.sh
@@ -16,7 +16,7 @@ rm $LINKTONODE;
 #remove older version of node:
 rm -R -f /opt/nodejs/;
 #remove symlinks
-rm /usr/bin/node /usr/sbin/node /sbin/node /sbin/node /usr/local/bin/node /usr/bin/npm /usr/sbin/npm /sbin/npm /usr/local/bin/npm;
+rm /usr/bin/node /usr/sbin/node /sbin/node /sbin/node /usr/local/bin/node /usr/bin/npm /usr/sbin/npm /sbin/npm /usr/local/bin/npm 2> /dev/null;
 #This next line will copy Node over to the appropriate folder.
 mv /root/tempNode/$NODEFOLDER /opt/nodejs/;
 #This line will remove the nodeJs tar we downloaded.


### PR DESCRIPTION
Piping output to null to prevent script fail when symlinks don't exist